### PR TITLE
Version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.0.0 - 2025-07-05
+
+_This release includes a potentially breaking change and updates the compatible Python versions._
+
+### Changed
+
+* (**BREAKING**) Use the [IANA-registered](https://www.iana.org/assignments/media-types/application/vnd.msgpack) `application/vnd.msgpack` MIME type, instead of `application/x-msgpack` previously.
+  * This impacts both the detection of msgpack-acceptable requests, as well as the MIME type used for encoding responses.
+  * To continue using `application/x-msgpack` or to use any other MIME type suitable for your needs, use the new `content_type` argument on `MessagePackMiddleware`. (Pull #30)
+
+### Removed
+
+* Drop official support for Python 3.6, 3.7 and 3.8 which have reached EOL. (It is likely this version remains compatible in practice, but no further maintenance will be provided for these Python versions.) (Pull #29)
+
+### Added
+
+* Add official support for Python 3.9 through 3.13. (Pull #29)
+
 ## 1.1.0 - 2021-10-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 app.add_middleware(MessagePackMiddleware)
 ```
 
-_(You may want to adapt this snippet to your framework-specific middleware API.)_
+_(Adapt this snippet to your framework-specific middleware API.)_
 
 This gives you the bandwitdth usage reduction benefits of MessagePack without having to change existing code.
 
@@ -21,8 +21,10 @@ This gives you the bandwitdth usage reduction benefits of MessagePack without ha
 Install with pip:
 
 ```bash
-pip install "msgpack-asgi==1.*"
+pip install "msgpack-asgi==2.*"
 ```
+
+**Be sure to pin to the latest major version**, as above. Breaking changes may occur across major versions. If so, details on migration steps will be provided in CHANGELOG.md.
 
 ## Quickstart
 
@@ -171,9 +173,9 @@ MessagePackMiddleware(
 **Parameters described**:
 
 * `app`: an ASGI app to add msgpack support to
-* _(Optional)_ `packb` - callable: msgpack encoding function. Defaults to `msgpack.packb`.
-* _(Optional)_ `unpackb` - callable: msgpack decoding function. Defaults to `msgpack.unpackb`.
-* _(Optional)_ _(New in 2.0.0)_ `content_type` - str: the content type (aka MIME type) to use for detecting incoming msgpack requests or sending msgpack responses. Defaults to the IANA-registered `application/vnd.msgpack` MIME type. Use this option when working with systems that use older non-standardcontent types such as `application/x-msgpack`.
+* `packb` - callable (Optional, Added in 1.1.0): msgpack encoding function. Defaults to `msgpack.packb`.
+* `unpackb` - callable _(Optional, Added in 1.1.0)_: msgpack decoding function. Defaults to `msgpack.unpackb`.
+* `content_type` - str _(Optional, Added in 2.0.0)_: the content type (_a.k.a_ MIME type) to use for detecting incoming msgpack requests or sending msgpack responses. Defaults to the IANA-registered `application/vnd.msgpack` MIME type. Use this option when working with older systems that send or expect e.g. `application/x-msgpack`.
 
 ## License
 


### PR DESCRIPTION
## 2.0.0 - 2025-07-05

_This release includes a potentially breaking change and updates the compatible Python versions._

### Changed

* (**BREAKING**) Use the [IANA-registered](https://www.iana.org/assignments/media-types/application/vnd.msgpack) `application/vnd.msgpack` MIME type, instead of `application/x-msgpack` previously.
  * This impacts both the detection of msgpack-acceptable requests, as well as the MIME type used for encoding responses.
  * To continue using `application/x-msgpack` or to use any other MIME type suitable for your needs, use the new `content_type` argument on `MessagePackMiddleware`. (Pull #30)

### Removed

* Drop official support for Python 3.6, 3.7 and 3.8 which have reached EOL. (It is likely this version remains compatible in practice, but no further maintenance will be provided for these Python versions.) (Pull #29)

### Added

* Add official support for Python 3.9 through 3.13. (Pull #29)
